### PR TITLE
fix all except bindgen warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The library will evantually support multiple cryptographic primitves. Currently 
 
 Build
 -------------------
-Running `Cargo build` will also install PARI on the machine. Follow the `test_encryption` test for usage. 
+Running `cargo build` will also install PARI on the machine. Follow the `test_encryption` test for usage. 
 
 Contact
 -------------------

--- a/build.rs
+++ b/build.rs
@@ -1,22 +1,17 @@
 extern crate bindgen;
 
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
+
 fn main() {
-    let output = Command::new("./Configure")
+    let _ = Command::new("./Configure")
         .current_dir("depend/pari-2.11.2")
         .output()
         .expect("failed to execute process");
 
     Command::new("make")
-        .arg("install")
-        .current_dir("depend/pari-2.11.2")
-        .output()
-        .expect("failed to make");
-
-    Command::new("make")
-        .arg("install-lib-sta")
+        .arg("install-nodata")
         .current_dir("depend/pari-2.11.2")
         .output()
         .expect("failed to make");

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn main() {
         .expect("failed to execute process");
 
     Command::new("make")
-        .arg("all")
+        .arg("install")
         .current_dir("depend/pari-2.11.2")
         .output()
         .expect("failed to make");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,12 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 extern crate libc;
 extern crate paillier;
-use libc::c_long;
 extern crate curv;
 use crate::curv::arithmetic::traits::Converter;
 use curv::BigInt;
 use libc::c_char;
 use std::ffi::CStr;
 use std::ops::Neg;
-use std::ptr;
 use std::str;
 
 pub mod primitives;
@@ -125,7 +123,7 @@ impl BinaryQF {
 
         let bqf = BinaryQF::pari_qf_to_qf(pf);
 
-        let (bqf_norm, matrix) = bqf.normalize();
+        let (bqf_norm, _) = bqf.normalize();
         bqf_norm
     }
 
@@ -285,7 +283,7 @@ pub fn bn_to_gen(bn: &BigInt) -> GEN {
     let two_bn = BigInt::from(2);
     let all_ones_32bits = two_bn.pow(32) - BigInt::one();
     let mut array = [0u8; 4];
-    let mut ints_vec = (0..num_ints)
+    let ints_vec = (0..num_ints)
         .map(|i| {
             let masked_valued_bn =
                 (bn.clone() & all_ones_32bits.clone() << (i * size_int)) >> (i * size_int);
@@ -381,14 +379,6 @@ pub fn decimal_string_to_bn(dec_string: String) -> BigInt {
         res
     });
     bn * BigInt::from(negative_flag)
-}
-
-#[link(name = "pari")]
-extern "C" {
-    fn stoi(s: i64) -> GEN;
-    fn addii(x: GEN, y: GEN) -> GEN;
-    fn vecslice(A: GEN, j1: i64, j2: i64) -> GEN;
-    fn mpcmp(x: GEN, y: GEN) -> GEN;
 }
 
 #[cfg(test)]

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,5 +1,4 @@
-use super::{ABDeltaTriple, BinaryQF};
-use crate::gmul;
+use super::BinaryQF;
 use crate::pari_init;
 use curv::arithmetic::traits::Samplable;
 use curv::BigInt;
@@ -180,23 +179,21 @@ fn reciprocity(num: &BigInt, den: &BigInt) -> (i8) {
 
 //TODO: improve approximation
 fn numerical_log(x: &BigInt) -> BigInt {
-    let mut ai: BigInt;
-    let mut bi: BigInt;
     let mut aip1: BigInt;
     let mut bip1: BigInt;
     let two = BigInt::from(2);
-    let mut ai = (BigInt::one() + x).div_floor(&two);
-    let mut bi = x.sqrt();
+    let mut _ai = (BigInt::one() + x).div_floor(&two);
+    let mut _bi = x.sqrt();
     let mut k = 0;
     while k < 1000 {
         k = k + 1;
-        aip1 = (&ai + &bi).div_floor(&two);
-        bip1 = (ai * bi).sqrt();
-        ai = aip1;
-        bi = bip1;
+        aip1 = (&_ai + &_bi).div_floor(&two);
+        bip1 = (_ai * _bi).sqrt();
+        _ai = aip1;
+        _bi = bip1;
     }
 
-    let log = two * (x - &BigInt::one()).div_floor(&(ai + bi));
+    let log = two * (x - &BigInt::one()).div_floor(&(_ai + _bi));
     log
 }
 


### PR DESCRIPTION
This should address most of #1  except the warnings generated by bindgen about 128-bit integers not having a stable ABI.

Also changed `make all` to `make install`, because all includes documentation, which requires tex, and is not strictly necessary, I'd say.